### PR TITLE
Manually copy sparkle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10.1
+osx_image: xcode11.3
 language: objective-c
 before_install:
 - bash Scripts/decrypt.bash

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "sparkle-project/Sparkle" == 1.19.0
+github "sparkle-project/Sparkle" == 1.22.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "sparkle-project/Sparkle" "1.19.0"
+github "sparkle-project/Sparkle" "1.22.0"

--- a/MetaZ.xcodeproj/project.pbxproj
+++ b/MetaZ.xcodeproj/project.pbxproj
@@ -202,7 +202,6 @@
 		1BA326A010546F4600276F57 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1BA3269E10546F4600276F57 /* MainMenu.xib */; };
 		1BA326A310546F9700276F57 /* MZTags.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1BA326A110546F9700276F57 /* MZTags.strings */; };
 		1BA326C61054723000276F57 /* MetaZKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BA325C410545ACA00276F57 /* MetaZKit.framework */; };
-		1BA9B57C2089578D00DDC17F /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BA9B579208954BA00DDC17F /* Sparkle.framework */; };
 		1BA9B57D208957B200DDC17F /* MetaZKit.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 1BA325C410545ACA00276F57 /* MetaZKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1BAC8EDA13EB32110022D625 /* MetaZ.icns in Resources */ = {isa = PBXBuildFile; fileRef = 1BAC8ED913EB32110022D625 /* MetaZ.icns */; };
 		1BAC8FEB13ECAFF20022D625 /* metaz.png in Resources */ = {isa = PBXBuildFile; fileRef = 1BAC8FEA13ECAFF20022D625 /* metaz.png */; };
@@ -293,6 +292,8 @@
 		1BFEDE0118349138008A17D3 /* PosterBackgroundError.png in Resources */ = {isa = PBXBuildFile; fileRef = 1BFEDDFE18349138008A17D3 /* PosterBackgroundError.png */; };
 		1BFEDE0218349138008A17D3 /* PosterBackgroundMultiple.png in Resources */ = {isa = PBXBuildFile; fileRef = 1BFEDDFF18349138008A17D3 /* PosterBackgroundMultiple.png */; };
 		7F4F84D818CD1F8A00D002DA /* NSString+NumericCompare.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F4F84D618CD1F8000D002DA /* NSString+NumericCompare.m */; };
+		7FAD6A79241D7CAE005BCE8E /* Sparkle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7FAD6A78241D7CAE005BCE8E /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7FAD6A7A241D7D1F005BCE8E /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FAD6A78241D7CAE005BCE8E /* Sparkle.framework */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 /* End PBXBuildFile section */
@@ -482,6 +483,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				7FAD6A79241D7CAE005BCE8E /* Sparkle.framework in Copy Frameworks */,
 				1BA9B57D208957B200DDC17F /* MetaZKit.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -809,8 +811,6 @@
 		1BA326A210546F9700276F57 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = Framework/English.lproj/MZTags.strings; sourceTree = "<group>"; };
 		1BA326EE1054823100276F57 /* MZWriteQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MZWriteQueue.h; sourceTree = "<group>"; };
 		1BA326EF1054823100276F57 /* MZWriteQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MZWriteQueue.m; sourceTree = "<group>"; };
-		1BA9B579208954BA00DDC17F /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
-		1BA9B57F2089580C00DDC17F /* Checkouts */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Checkouts; path = Carthage/Checkouts; sourceTree = "<group>"; };
 		1BAC8ED913EB32110022D625 /* MetaZ.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = MetaZ.icns; path = App/resources/MetaZ.icns; sourceTree = "<group>"; };
 		1BAC8FEA13ECAFF20022D625 /* metaz.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = metaz.png; path = App/resources/metaz.png; sourceTree = "<group>"; };
 		1BAC912813F053980022D625 /* MZDateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MZDateFormatter.h; sourceTree = "<group>"; };
@@ -910,6 +910,7 @@
 		32CA4F630368D1EE00C91783 /* MetaZ_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MetaZ_Prefix.pch; path = App/MetaZ_Prefix.pch; sourceTree = "<group>"; };
 		7F4F84D518CD1F8000D002DA /* NSString+NumericCompare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+NumericCompare.h"; sourceTree = "<group>"; };
 		7F4F84D618CD1F8000D002DA /* NSString+NumericCompare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+NumericCompare.m"; sourceTree = "<group>"; };
+		7FAD6A78241D7CAE005BCE8E /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = App/Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* MetaZ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MetaZ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -997,7 +998,7 @@
 				1BA326C61054723000276F57 /* MetaZKit.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				1B0DEDE010610412009D293F /* Quartz.framework in Frameworks */,
-				1BA9B57C2089578D00DDC17F /* Sparkle.framework in Frameworks */,
+				7FAD6A7A241D7D1F005BCE8E /* Sparkle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1105,7 +1106,7 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1BA9B579208954BA00DDC17F /* Sparkle.framework */,
+				7FAD6A78241D7CAE005BCE8E /* Sparkle.framework */,
 				1B0DEDDF10610412009D293F /* Quartz.framework */,
 				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
 				1B523B8813F4B39400C20B7D /* SystemConfiguration.framework */,
@@ -1225,7 +1226,6 @@
 		1B449CEE10DCCAD500B9C751 /* External Sources */ = {
 			isa = PBXGroup;
 			children = (
-				1BA9B57F2089580C00DDC17F /* Checkouts */,
 				1B4CFF8E161CDED800B12009 /* AEVTBuilder */,
 				1B069665149BD32D00B5FA90 /* MGViewAnimation */,
 				1B523B4813F4B24E00C20B7D /* asi-http-request */,
@@ -2086,9 +2086,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "MetaZ" */;
 			buildPhases = (
+				1BA9B57B2089550F00DDC17F /* Carthage Update Frameworks */,
 				8D1107290486CEB800E47090 /* Resources */,
 				1BB6C11E1052B199001D3D1D /* Copy Frameworks */,
-				1BA9B57B2089550F00DDC17F /* carthage copy-frameworks */,
 				1BEA6F2F106EF6D5004B1A7F /* Copy Plugins */,
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
@@ -2311,6 +2311,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+			showEnvVarsInLog = 0;
 		};
 		1B2022FC10B393FD00EE548A /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2368,6 +2369,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -o errexit\nbash $SRCROOT/Scripts/make_diskimage.bash\n";
+			showEnvVarsInLog = 0;
 		};
 		1B76F8EB2415C2AE00CB8810 /* Sparkle Sign */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2388,6 +2390,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -o errexit\nbash $SRCROOT/Scripts/sparkle_sign.bash\n";
+			showEnvVarsInLog = 0;
 		};
 		1B76F8EE24169B9900CB8810 /* Sign AppleScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2410,22 +2413,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -o errexit\nbash $SRCROOT/Scripts/sign_applescript.bash\n";
+			showEnvVarsInLog = 0;
 		};
-		1BA9B57B2089550F00DDC17F /* carthage copy-frameworks */ = {
+		1BA9B57B2089550F00DDC17F /* Carthage Update Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/Mac/Sparkle.framework",
 			);
-			name = "carthage copy-frameworks";
+			name = "Carthage Update Frameworks";
 			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Sparkle.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "PATH=${PATH}:/usr/local/bin:/opt/local/bin\ncarthage copy-frameworks\n";
+			shellScript = "PATH=${PATH}:/usr/local/bin:/opt/local/bin\ncarthage update\n";
+			showEnvVarsInLog = 0;
 		};
 		1BEA6D70106EA6D1004B1A7F /* Build Documentation */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3084,7 +3087,7 @@
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)\"",
+					"$(SRCROOT)",
 					"\"$(SRCROOT)/Externals\"",
 					"\"$(PROJECT_DIR)/Carthage/Build/Mac\"",
 				);
@@ -3098,6 +3101,7 @@
 					Externals/UKDockProgressIndicator,
 					Externals/AEVTBuilder,
 					"Externals/google-toolbox-for-mac/**",
+					Carthage/Checkouts/Sparkle,
 				);
 				IBC_OTHER_FLAGS = "--plugin /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Resources/ImageKitIBPlugin.ibplugin";
 				INFOPLIST_FILE = App/Info.plist;
@@ -3838,7 +3842,7 @@
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)\"",
+					"$(SRCROOT)",
 					"\"$(SRCROOT)/Externals\"",
 					"\"$(PROJECT_DIR)/Carthage/Build/Mac\"",
 				);
@@ -3852,6 +3856,7 @@
 					Externals/UKDockProgressIndicator,
 					Externals/AEVTBuilder,
 					"Externals/google-toolbox-for-mac/**",
+					Carthage/Checkouts/Sparkle,
 				);
 				IBC_OTHER_FLAGS = "--plugin /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Resources/ImageKitIBPlugin.ibplugin";
 				INFOPLIST_FILE = App/Info.plist;
@@ -3875,7 +3880,7 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)\"",
+					"$(SRCROOT)",
 					"\"$(SRCROOT)/Externals\"",
 					"\"$(PROJECT_DIR)/Carthage/Build/Mac\"",
 				);
@@ -3887,6 +3892,7 @@
 					Externals/UKDockProgressIndicator,
 					Externals/AEVTBuilder,
 					"Externals/google-toolbox-for-mac/**",
+					Carthage/Checkouts/Sparkle,
 				);
 				IBC_OTHER_FLAGS = "--plugin /System/Library/Frameworks/Quartz.framework/Versions/A/Frameworks/ImageKit.framework/Resources/ImageKitIBPlugin.ibplugin";
 				INFOPLIST_FILE = App/Info.plist;


### PR DESCRIPTION
This changes the build process to only use Carthage to create the Sparkle framework. The framework is copied into place by configuration in Xcode. This fixes a signing issues when building in Xcode 11. Also, Sparkle was updated.