### PR TITLE
Remote data download improvements (multithread, caching)

### DIFF
--- a/Framework/src/RemoteData.swift
+++ b/Framework/src/RemoteData.swift
@@ -7,6 +7,25 @@
 
 import Foundation
 
+fileprivate class RemoteCaching {
+    // Used a session that caches its results
+    static let remoteLoadSession: URLSession = {
+        // Create URL Session Configuration
+        let configuration = URLSessionConfiguration.default.copy() as! URLSessionConfiguration
+
+        // Set the in-memory cache to 128 MB
+        let cache = URLCache()
+        cache.memoryCapacity = 128 * 1024 * 1024
+        configuration.urlCache = cache
+
+        // Define Request Cache Policy
+        configuration.requestCachePolicy = .useProtocolCachePolicy
+        configuration.urlCache = cache
+
+        return URLSession(configuration: configuration)
+    }()
+}
+
 @objc public class RemoteData : NSObject {
     private static let queue = DispatchQueue(label: "io.metaz.RemoteDataQueue")
     
@@ -97,8 +116,7 @@ import Foundation
                 if self.data == nil {
                     return;
                 }
-                
-                URLSession.dataTask(url: url) { (d, resp, err) in
+                RemoteCaching.remoteLoadSession.dataTask(with: url) { (d, resp, err) in
                     if let error = err {
                         let info = [NSLocalizedDescriptionKey: error.localizedDescription]
                         let statusCode = (resp as? HTTPURLResponse)?.statusCode ?? 0


### PR DESCRIPTION
This patch adds two performance improvements when working with download search result data (posters)

1. Added a URLSession cache for remote data downloading.

When working with a tv series, I found that the loading of the poster information for each tv episode re-loads ALL of the posters for the series for each episode, even if the poster data URL was the same for the previously selected episode.

This adds a URL cache to the URLSession to avoid re-downloading data for the same URL (ive fixed the cache size to 128 meg) makes working with an entire TV series a MUCH smoother experience.

For example, for a 'popular' tv series, seeing the first poster for a selected search result might take 10-20 seconds
(as it was downloading 20-30 posters in the background before displaying). For each episode in the series, it would re-download the same URL data for the posters. Adding the cache here means it is only downloaded once.

2. Support multithreaded downloads for RemoteData

All posters for a search selection are downloaded before the first one is shown in the UI. For popular tv series, there can be 20 or more posters for the series which are all downloaded before the 'first' poster appears in the UI. Currently, the posters are downloaded serially which means that on a slow-ish connection to tvDB (for eg) this can take quite a while before the 'first' poster appears in the UI.

This patch moves patch downloading onto the global 'utility' thread which allows for multiple simultaneous downloads, limiting the number of simultaneous downloads to 10.