### PR TITLE
Fixed outdated OS nomenclature

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Introduction [![Build Status](https://travis-ci.org/griff/metaz.svg?branch=develop)](https://travis-ci.org/griff/metaz)
 
-MetaZ is an mp4 meta-data editor for OS X.  
+MetaZ is an mp4 meta-data editor for macOS.  
 It started its life when another great meta-data editor MetaX stopped getting
 updated, some of the web-services it used changed in ways that broke
 functionality and it had some really anoying (to us at least) little missing


### PR DESCRIPTION
It's hard to take this seriously: "MetaX stopped getting updated" when the OS is written as "OS X".