### PR TITLE
Carthage now uses binary Sparkle builds to fix build breaks.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "sparkle-project/Sparkle" == 1.22.0
+binary "https://sparkle-project.org/Carthage/Sparkle.json" == 1.27.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "sparkle-project/Sparkle" "1.22.0"
+binary "https://sparkle-project.org/Carthage/Sparkle.json" "1.27.1"


### PR DESCRIPTION
Sparkle with Carthage doesn't work anymore with the GitHub Cartfile format. Switch to the recommended binary format. Upgraded Sparkle to 1.27.1 as this is the only 1.x version available in binary format.